### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Appknoxadvanced.yml
+++ b/.github/workflows/Appknoxadvanced.yml
@@ -29,6 +29,9 @@ on:
 jobs:
   appknox:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/Aaayayayg/Apks-Bundle-Android-Apps-and-games/security/code-scanning/2](https://github.com/Aaayayayg/Apks-Bundle-Android-Apps-and-games/security/code-scanning/2)

In general, this issue is fixed by adding a `permissions` block that explicitly restricts the `GITHUB_TOKEN` to the minimum scopes needed by the workflow. This can be done at the workflow root (applies to all jobs) or at the job level (applies only to that job). For this workflow, the job’s steps require: read access to repository contents for `actions/checkout`, and permission to upload SARIF security results for `github/codeql-action/upload-sarif`. They do not require broader write access (e.g., to commits, issues, or pull requests).

The best fix without changing existing functionality is to add a `permissions` block at the job level for `appknox` in `.github/workflows/Appknoxadvanced.yml`, just under `runs-on: ubuntu-latest`. This block should grant `contents: read` and `security-events: write`, which is the minimal set required for the listed actions. No changes are required to the steps themselves. The YAML indentation must be preserved so that `permissions` is at the same level as `runs-on` within the `appknox` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
