### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Appknox3.1advanced.yml
+++ b/.github/workflows/Appknox3.1advanced.yml
@@ -28,6 +28,8 @@ on:
     branches: [ "Master" ]
 jobs:
   appknox:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Potential fix for [https://github.com/Aaayayayg/Apks-Bundle-Android-Apps-and-games/security/code-scanning/3](https://github.com/Aaayayayg/Apks-Bundle-Android-Apps-and-games/security/code-scanning/3)

In general, the fix is to explicitly declare a `permissions` block to scope down the `GITHUB_TOKEN` to the minimum necessary, instead of relying on inherited repository/organization defaults. This block can be defined at the workflow root (applies to all jobs) or at the job level.

For this workflow, the job only checks out code, builds, calls a third‑party action with a secret, and uploads a SARIF file. None of these require write access to repository contents. A conservative and sufficient fix is to set `permissions: contents: read` at the job (or workflow) level. This satisfies CodeQL’s recommendation and adheres to least privilege without impacting functionality. The `github/codeql-action/upload-sarif` action uses its own API scopes, but for uploading SARIF to the Security tab, `contents: read` is adequate; it does not need to push commits or modify issues.

Concretely, in `.github/workflows/Appknox3.1advanced.yml`, add a `permissions:` block with `contents: read` under either the top-level keys (after `on:` / before `jobs:`) or directly under the `appknox` job. To keep the change tightly focused on the reported location (`runs-on: ubuntu-latest` in the job), we’ll add it at the job level by inserting:

```yaml
    permissions:
      contents: read
```

between `appknox:` and `runs-on: ubuntu-latest`. No additional imports, methods, or other definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
